### PR TITLE
Tiny Fix for Payloads less than 1024 bytes

### DIFF
--- a/Christmas/Christmas/main.c
+++ b/Christmas/Christmas/main.c
@@ -324,7 +324,7 @@ int main(int argc, char* argv[]) {
 		// Increment Write Process Number
 		dwCurrentProcess++;
 
-		if (dwCurrentProcess == dwWriteProcesses) {
+		if (dwCurrentProcess >= dwWriteProcesses) {
 			// Fork With Target Process Handle & Base Address & dummy arg x3
 			// Christmas.exe 00000000000000DA 00007FF9C37EB78F 256 256 256
 			printf("[%d] Payload Is Written To Target Process \n", argc);


### PR DESCRIPTION
Hi,

I don't know if anyone has a shellcode less than 1024 byte (in my case to test the PoC, I used a notepad spawn shellcode), dwCurrentProcess variable becomes 1 after the first loop and the code doesn't stop for injection, which leads to "Invalid access to memory location" from WriteProcessMemory API. Therefore, I updated the relevant comparison to be greater than or equal to.

 